### PR TITLE
#35 fix: 로딩중, page 안넘어가는거 수정

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-VITE_BACKEND_BASE_URL=http://localhost:8080
+VITE_BACKEND_BASE_URL=https://garden-test.duckdns.org

--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/logo-mark.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Memoria</title>
+    <title>지식정원</title>
   </head>
   <body>
     <div id="root"></div>

--- a/public/logo-mark.svg
+++ b/public/logo-mark.svg
@@ -1,0 +1,16 @@
+<svg width="64" height="64" viewBox="0 0 30 33" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <mask id="logo-mark-mask" maskUnits="userSpaceOnUse" x="0" y="0" width="30" height="33">
+    <rect x="0.833" y="0.833" width="28.334" height="31.667" rx="4.167" fill="white" />
+    <rect x="10.417" y="10.417" width="13.333" height="3.333" rx="1.667" fill="black" />
+    <rect x="3.333" y="24.167" width="25.833" height="3.333" rx="1.667" fill="black" />
+  </mask>
+  <rect
+    x="0.833"
+    y="0.833"
+    width="28.334"
+    height="31.667"
+    rx="4.167"
+    fill="#111111"
+    mask="url(#logo-mark-mask)"
+  />
+</svg>

--- a/src/components/common/LoadingState.jsx
+++ b/src/components/common/LoadingState.jsx
@@ -1,0 +1,30 @@
+import "../../styles/common/LoadingState.css";
+
+const LoadingState = ({
+  title = "불러오는 중입니다",
+  description = "잠시만 기다려주세요.",
+  compact = false,
+  className = "",
+}) => {
+  const classes = [
+    "loading-state",
+    compact ? "loading-state--compact" : "",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div className={classes} role="status" aria-live="polite">
+      <div className="loading-state-spinner" aria-hidden="true">
+        <span className="loading-state-spinner-dot" />
+      </div>
+      <div className="loading-state-copy">
+        <p className="loading-state-title">{title}</p>
+        {description ? <p className="loading-state-description">{description}</p> : null}
+      </div>
+    </div>
+  );
+};
+
+export default LoadingState;

--- a/src/components/goals/GoalCard.jsx
+++ b/src/components/goals/GoalCard.jsx
@@ -1,5 +1,6 @@
 import { Plus, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
+import LoadingState from "../common/LoadingState";
 import TaskRow from "./TaskRow";
 import "../../styles/goals/GoalCard.css";
 
@@ -69,7 +70,11 @@ const GoalCard = ({
             ) : (
                 <>
                     {loadingTasks ? (
-                        <p className="goal-subtle">과제를 불러오는 중...</p>
+                        <LoadingState
+                            title="과제를 불러오는 중입니다"
+                            compact
+                            className="goal-subtle"
+                        />
                     ) : tasks.length > 0 ? (
                         <ul className="goal-tasklist">
                             {tasks.map((task) => (

--- a/src/components/mindmap/MindMapView.jsx
+++ b/src/components/mindmap/MindMapView.jsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import tree from "../../assets/mindmap/tree.svg";
+import LoadingState from "../common/LoadingState";
 import AppleNode from "./AppleNode";
 
 const toPositionedNodes = (nodes = []) => {
@@ -30,7 +31,17 @@ const toPositionedNodes = (nodes = []) => {
 export default function MindMapView({ nodes = [], isLoading, error, onNodeClick }) {
     const positionedNodes = useMemo(() => toPositionedNodes(nodes), [nodes]);
 
-    if (isLoading) return <div>로딩중...</div>;
+    if (isLoading) {
+        return (
+            <div className="mindmap-view">
+                <LoadingState
+                    title="지식나무를 불러오는 중입니다"
+                    description="학습 흐름을 정리하고 있어요."
+                    className="mindmap-view-loading"
+                />
+            </div>
+        );
+    }
     if (error) return <div>불러오기 실패</div>;
 
     return (

--- a/src/components/mypage/GoalList.jsx
+++ b/src/components/mypage/GoalList.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { deleteMyGoal, getMyGoals } from "../../api/mypage.api";
+import LoadingState from "../common/LoadingState";
 import GoalCard from "./GoalCard";
 import { MOCK_GOALS } from "./types";
 
@@ -111,7 +112,15 @@ export default function GoalList() {
     }
   };
 
-  if (loading) return <div className="goal-state">목표를 불러오는 중...</div>;
+  if (loading) {
+    return (
+      <LoadingState
+        title="목표 목록을 불러오는 중입니다"
+        description="현재 진행 중인 목표를 모으고 있어요."
+        className="goal-state"
+      />
+    );
+  }
 
   return (
     <section className="goal-list-wrap">

--- a/src/components/records/StudyRecordList.jsx
+++ b/src/components/records/StudyRecordList.jsx
@@ -1,6 +1,6 @@
 import StudyRecordCard from "./StudyRecordCard";
 import { ChevronLeft, ChevronRight } from "lucide-react";
- 
+import LoadingState from "../common/LoadingState";
 
 const StudyRecordList = ({
     records = [],
@@ -35,10 +35,11 @@ const StudyRecordList = ({
         <div className="record-list-wrapper">
             <div className="record-list">
                 {isLoading && (
-                    <div className="record-empty-state">
-                        <div className="record-empty-icon">⏳</div>
-                        <h3 className="record-empty-title">학습 기록을 불러오는 중입니다</h3>
-                    </div>
+                    <LoadingState
+                        title="학습 기록을 불러오는 중입니다"
+                        description="최근에 작성한 기록을 정리하고 있어요."
+                        className="record-loading-state"
+                    />
                 )}
                 {!isLoading && !hasRecords && (
                     <div className="record-empty-state">
@@ -49,12 +50,13 @@ const StudyRecordList = ({
                         </p>
                     </div>
                 )}
-                {records.map((record) => (
-                    <StudyRecordCard key={record.id} record={record} />
-                ))}
+                {!isLoading &&
+                    records.map((record) => (
+                        <StudyRecordCard key={record.id} record={record} />
+                    ))}
             </div>
 
-            {hasRecords && (
+            {!isLoading && hasRecords && (
                 <div className="record-pagination">
                     <button type="button" className="page-btn" onClick={onPrev} disabled={!canPrev}>
                         <ChevronLeft size={16} />

--- a/src/hooks/useGoals.js
+++ b/src/hooks/useGoals.js
@@ -70,7 +70,7 @@ export default function useGoals() {
     return () => clearTimeout(timer);
   }, [errorMessage]);
 
-  const loadGoals = useCallback(async (nextPage = page) => {
+  const loadGoals = useCallback(async (nextPage = 0) => {
     setLoadingGoals(true);
     try {
       const pageData = await fetchGoals(nextPage);
@@ -83,7 +83,7 @@ export default function useGoals() {
     } finally {
       setLoadingGoals(false);
     }
-  }, [page, setUiError]);
+  }, [setUiError]);
 
   const refreshTasks = useCallback(async (goalId) => {
     setTasksLoadingByGoalId((prev) => ({ ...prev, [goalId]: true }));
@@ -204,4 +204,3 @@ export default function useGoals() {
     toggleTaskCompleted,
   };
 }
-

--- a/src/hooks/useMindMapApi.js
+++ b/src/hooks/useMindMapApi.js
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getMindMap, normalizeMindMapParams } from "../api/mindmap.api";
 
 export const useMindMapQuery = (initialParams = {}) => {
@@ -10,21 +10,27 @@ export const useMindMapQuery = (initialParams = {}) => {
     });
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
+    const requestSeqRef = useRef(0);
 
     const refetch = useCallback(
         async (nextParams) => {
             const resolved = normalizeMindMapParams(nextParams ?? params);
+            const requestSeq = requestSeqRef.current + 1;
+            requestSeqRef.current = requestSeq;
             setLoading(true);
             setError(null);
 
             try {
                 const response = await getMindMap(resolved);
+                if (requestSeqRef.current !== requestSeq) return null;
                 setData(response);
                 return response;
             } catch (err) {
+                if (requestSeqRef.current !== requestSeq) return null;
                 setError(err);
                 throw err;
             } finally {
+                if (requestSeqRef.current !== requestSeq) return;
                 setLoading(false);
             }
         },

--- a/src/hooks/useRecordApi.js
+++ b/src/hooks/useRecordApi.js
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
     createRecord,
     deleteRecord,
@@ -38,21 +38,27 @@ export const useRecordListQuery = (initialParams = { page: 1, size: 4 }) => {
     });
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
+    const requestSeqRef = useRef(0);
 
     const refetch = useCallback(
         async (nextParams) => {
             const resolvedParams = normalizeListParams(nextParams ?? params);
+            const requestSeq = requestSeqRef.current + 1;
+            requestSeqRef.current = requestSeq;
             setLoading(true);
             setError(null);
             try {
                 const response = await getRecordList(resolvedParams);
+                if (requestSeqRef.current !== requestSeq) return null;
                 setData(response);
                 return response;
             } catch (err) {
                 const normalized = normalizeApiError(err, "기록 목록 조회에 실패했습니다.");
+                if (requestSeqRef.current !== requestSeq) return null;
                 setError(normalized);
                 throw normalized;
             } finally {
+                if (requestSeqRef.current !== requestSeq) return;
                 setLoading(false);
             }
         },

--- a/src/pages/auth/OauthCallback.jsx
+++ b/src/pages/auth/OauthCallback.jsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import api from "../../api/axios";
 import "../../styles/OauthCallback.css";
 import { useAuth } from "../../context/AuthContext";
+import LoadingState from "../../components/common/LoadingState";
 
 export default function OauthCallback() {
   const nav = useNavigate();
@@ -74,9 +75,11 @@ export default function OauthCallback() {
   return (
     <div className="oauth-callback">
       <div className="oauth-card">
-        <div className="oauth-spinner" />
-        <h2 className="oauth-title">로그인 처리 중</h2>
-        <p className="oauth-sub">{msg}</p>
+        <LoadingState
+          title="로그인 처리 중입니다"
+          description={msg}
+          className="oauth-loading-state"
+        />
       </div>
     </div>
   );

--- a/src/pages/dashboard/Dashboard.jsx
+++ b/src/pages/dashboard/Dashboard.jsx
@@ -3,6 +3,7 @@ import DashboardSummaryCards from "../../components/dashboard/DashboardSummaryCa
 import RecentActivities from "../../components/dashboard/RecentActivities";
 import CategoryStatsBar from "../../components/dashboard/CategoryStatsBar";
 import DashboardActions from "../../components/dashboard/DashboardActions";
+import LoadingState from "../../components/common/LoadingState";
 
 import "../../styles/Dashboard/Dashboard.css";
 import "../../styles/global.css";
@@ -185,7 +186,11 @@ const Dashboard = () => {
                     <button className="add-study-record-btn" onClick={() => window.location.href = "/records"}>+ 새 학습 기록 작성</button>
 
                     {loading ? (
-                        <p>로딩중...</p>
+                        <LoadingState
+                            title="대시보드 데이터를 불러오는 중입니다"
+                            description="최근 학습 현황을 준비하고 있어요."
+                            className="dashboard-loading"
+                        />
                     ) : error ? (
                         <div className="dashboard-status">
                             <p>대시보드 데이터를 불러오지 못했습니다</p>

--- a/src/pages/goals/GoalManage.jsx
+++ b/src/pages/goals/GoalManage.jsx
@@ -1,4 +1,5 @@
 import Header from "../../components/common/Header";
+import LoadingState from "../../components/common/LoadingState";
 import GoalCard from "../../components/goals/GoalCard";
 import GoalCreateModal from "../../components/goals/GoalCreateModal";
 import useGoals from "../../hooks/useGoals";
@@ -45,7 +46,11 @@ const GoalManage = () => {
             />
             <main className="goals-list">
                 {loadingGoals ? (
-                    <div className="goal-empty">목표를 불러오는 중...</div>
+                    <LoadingState
+                        title="목표를 불러오는 중입니다"
+                        description="세부 과제 정보도 함께 준비하고 있어요."
+                        className="goal-empty goal-loading"
+                    />
                 ) : goals.length === 0 ? (
                     <section className="goal-empty-card">
                         <h3 className="goal-title">아직 목표가 없습니다</h3>

--- a/src/pages/mypage/AchievementsPage.jsx
+++ b/src/pages/mypage/AchievementsPage.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import MyPageLayout from "../../components/mypage/MyPageLayout";
+import LoadingState from "../../components/common/LoadingState";
 import { getAchievements } from "../../api/achievement.api";
 import styles from "./AchievementsPage.module.css";
 
@@ -77,7 +78,13 @@ export default function AchievementsPage() {
           ))}
         </div>
 
-        {loading && <div className={styles.stateText}>로딩중...</div>}
+        {loading && (
+          <LoadingState
+            title="업적 데이터를 불러오는 중입니다"
+            description="뱃지 달성 현황을 확인하고 있어요."
+            className={styles.loadingState}
+          />
+        )}
         {!loading && error && <div className={styles.errorText}>{error}</div>}
 
         {!loading && !error && (

--- a/src/pages/mypage/AchievementsPage.module.css
+++ b/src/pages/mypage/AchievementsPage.module.css
@@ -60,6 +60,10 @@
   color: #6b7280;
 }
 
+.loadingState {
+  border-radius: 12px;
+}
+
 .errorText {
   border: 1px solid #fecaca;
   background: #fef2f2;
@@ -184,4 +188,3 @@
   font-weight: 800;
   color: #6b7280;
 }
-

--- a/src/pages/mypage/RecentActivityPage.jsx
+++ b/src/pages/mypage/RecentActivityPage.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import LoadingState from "../../components/common/LoadingState";
 import MyPageLayout from "../../components/mypage/MyPageLayout";
 import RecentActivityCard from "../../components/mypage/RecentActivityCard";
 import { getMyPageRecent } from "../../api/mypage.api";
@@ -34,7 +35,13 @@ export default function RecentActivityPage() {
       title="최근 학습 기록"
       description="최근 학습한 내용들을 확인하고 이어서 학습해보세요."
     >
-      {loading && <div className="recent-loading">불러오는 중...</div>}
+      {loading && (
+        <LoadingState
+          title="최근 학습 활동을 불러오는 중입니다"
+          description="잠시만 기다려주세요."
+          className="recent-loading"
+        />
+      )}
 
       {!loading && error && (
         <div className="recent-error">

--- a/src/pages/records/StudyRecordDetail.jsx
+++ b/src/pages/records/StudyRecordDetail.jsx
@@ -11,6 +11,7 @@ import Other2 from "../../assets/records/detail/Other2.svg";
 import pencil from "../../assets/records/detail/pencil.svg";
 import trash from "../../assets/records/detail/trash.svg";
 import Header from "../../components/common/Header";
+import LoadingState from "../../components/common/LoadingState";
 import StudyRecordCreateModal from "../../components/records/StudyRecordCreateModal";
 import MarkdownPreview from "../../components/common/MarkdownPreview";
 import {
@@ -109,7 +110,10 @@ const StudyRecordDetail = () => {
 
                 <main className="detail-main">
                     <section className="detail-card">
-                        <h1 className="detail-title">기록을 불러오는 중입니다.</h1>
+                        <LoadingState
+                            title="기록을 불러오는 중입니다"
+                            description="선택한 학습 내용을 준비하고 있어요."
+                        />
                     </section>
                 </main>
             </div>

--- a/src/styles/Dashboard/Dashboard.css
+++ b/src/styles/Dashboard/Dashboard.css
@@ -70,6 +70,10 @@
     font-size: 16px;
 }
 
+.dashboard-loading {
+    margin-bottom: 12px;
+}
+
 .dashboard-retry-btn {
     border: 1px solid #d1d5db;
     background: #fff;

--- a/src/styles/MyPage.css
+++ b/src/styles/MyPage.css
@@ -59,7 +59,7 @@
   top: 0;
   width: 4px;
   height: 100%;
-  background: #22c55e;
+  background: #2563eb;
 }
 
 .my-nav-item.is-withdraw {
@@ -458,7 +458,6 @@
   font-weight: 600;
 }
 
-.recent-loading,
 .recent-error,
 .recent-empty {
   padding: 20px;
@@ -466,6 +465,12 @@
   background: #fff;
   border: 1px solid #e5e7eb;
   font-size: 14px;
+}
+
+.recent-loading {
+  padding: 0;
+  border: 0;
+  background: transparent;
 }
 
 .my-btn.danger {
@@ -505,12 +510,10 @@
 }
 
 .goal-state {
-  border: 1px solid #e5e7eb;
-  border-radius: 12px;
-  background: #fff;
-  color: #6b7280;
-  padding: 14px 16px;
-  font-size: 14px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
 }
 
 .goal-empty-card {

--- a/src/styles/OauthCallback.css
+++ b/src/styles/OauthCallback.css
@@ -12,32 +12,12 @@
   border-radius: var(--radius);
   box-shadow: var(--shadow);
   padding: 28px;
-  text-align: center;
+  text-align: left;
 }
 
-.oauth-title {
-  margin: 0 0 8px;
-  font-size: 18px;
-  font-weight: 800;
-  letter-spacing: -0.2px;
-}
-
-.oauth-sub {
-  margin: 0 0 18px;
-  color: var(--muted);
-  font-size: 14px;
-}
-
-.oauth-spinner {
-  width: 36px;
-  height: 36px;
-  border-radius: 999px;
-  border: 3px solid #d1d5db;
-  border-top-color: var(--brand);
-  margin: 0 auto 16px;
-  animation: spin 0.9s linear infinite;
-}
-
-@keyframes spin {
-  to { transform: rotate(360deg); }
+.oauth-loading-state {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
 }

--- a/src/styles/Onboarding.css
+++ b/src/styles/Onboarding.css
@@ -53,8 +53,8 @@
 }
 
 .onboard-input:focus {
-  border-color: rgba(47, 111, 78, 0.55);
-  box-shadow: 0 0 0 3px rgba(47, 111, 78, 0.14);
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.14);
 }
 
 .onboard-textarea {
@@ -69,8 +69,8 @@
 }
 
 .onboard-textarea:focus {
-  border-color: rgba(47, 111, 78, 0.55);
-  box-shadow: 0 0 0 3px rgba(47, 111, 78, 0.14);
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.14);
 }
 
 .onboard-chip-grid {
@@ -91,8 +91,8 @@
 }
 
 .onboard-chip.is-selected {
-  border-color: rgba(47, 111, 78, 0.6);
-  background: rgba(47, 111, 78, 0.1);
+  border-color: #2563eb;
+  background: rgba(37, 136, 235, 0.1);
   color: #1f2937;
 }
 
@@ -121,7 +121,7 @@
   height: 46px;
   border: none;
   border-radius: 12px;
-  background: #2f6f4e;
+  background: #2563eb;
   color: #fff;
   font-weight: 800;
   cursor: pointer;

--- a/src/styles/SignupAgreement.css
+++ b/src/styles/SignupAgreement.css
@@ -78,7 +78,7 @@
 .btn-primary{
   flex: 1;
   border: none;
-  background: #2f6f4e;
+  background: #2563eb;
   color: #fff;
 }
 .btn-primary:disabled{

--- a/src/styles/common/LoadingState.css
+++ b/src/styles/common/LoadingState.css
@@ -1,0 +1,89 @@
+.loading-state {
+  --loading-accent: #1d4ed8;
+  --loading-border: #d9e4ff;
+  --loading-bg: linear-gradient(135deg, #f8fbff 0%, #eef4ff 100%);
+  --loading-text: #0f172a;
+  --loading-muted: #475569;
+
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 16px 18px;
+  border: 1px solid var(--loading-border);
+  border-radius: 14px;
+  background: var(--loading-bg);
+}
+
+.loading-state-spinner {
+  position: relative;
+  width: 36px;
+  height: 36px;
+  border-radius: 9999px;
+  border: 3px solid #c9d9ff;
+  border-top-color: var(--loading-accent);
+  animation: loading-spin 0.8s linear infinite;
+  flex-shrink: 0;
+}
+
+.loading-state-spinner-dot {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 8px;
+  height: 8px;
+  border-radius: 9999px;
+  background: var(--loading-accent);
+  transform: translate(-50%, -50%);
+}
+
+.loading-state-copy {
+  display: grid;
+  gap: 4px;
+}
+
+.loading-state-title {
+  margin: 0;
+  color: var(--loading-text);
+  font-size: 15px;
+  font-weight: 800;
+}
+
+.loading-state-description {
+  margin: 0;
+  color: var(--loading-muted);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.loading-state--compact {
+  padding: 8px 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.loading-state--compact .loading-state-spinner {
+  width: 22px;
+  height: 22px;
+  border-width: 2px;
+}
+
+.loading-state--compact .loading-state-spinner-dot {
+  width: 5px;
+  height: 5px;
+}
+
+.loading-state--compact .loading-state-title {
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.loading-state--compact .loading-state-description {
+  font-size: 12px;
+}
+
+@keyframes loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/styles/goals/GoalCard.css
+++ b/src/styles/goals/GoalCard.css
@@ -183,3 +183,10 @@
     color: #64748b;
     font-size: 13px;
 }
+
+.goal-subtle.loading-state {
+    border: 0;
+    background: transparent;
+    padding-left: 0;
+    padding-right: 0;
+}

--- a/src/styles/goals/GoalManage.css
+++ b/src/styles/goals/GoalManage.css
@@ -27,6 +27,11 @@
     font-weight: 600;
 }
 
+.goal-loading {
+    justify-content: flex-start;
+    padding: 20px;
+}
+
 .goal-empty-card {
     border: 1px solid #d7dbe2;
     border-radius: 10px;

--- a/src/styles/mindmap/MindMap.css
+++ b/src/styles/mindmap/MindMap.css
@@ -30,6 +30,11 @@
     background: #fffefc;
 }
 
+.mindmap-view-loading {
+    width: min(92%, 420px);
+    margin: auto;
+}
+
 .mindmap-tree {
     width: 100%;
     display: block;

--- a/src/styles/records/StudyRecord.css
+++ b/src/styles/records/StudyRecord.css
@@ -81,6 +81,10 @@
     padding: 28px 20px;
 }
 
+.record-loading-state {
+    min-height: 240px;
+}
+
 .record-empty-icon {
     width: 54px;
     height: 54px;


### PR DESCRIPTION
## 요약
Records/MindMap 조회 시 로딩 상태에서 이전 조회 결과가 함께 보여 사용자에게 잘못된 상태가 노출됩니다.

## 영향 범위
- Records 목록 화면
- MindMap 화면
- (관련) Goals 페이지네이션 초기화 이슈도 함께 확인됨

## 재현 방법
1. Records 또는 MindMap 화면 진입
2. 카테고리/검색어/페이지를 빠르게 변경
3. 로딩 UI가 표시되는 동안 이전 데이터가 하단에 함께 노출됨

## 기대 결과
- 로딩 중에는 이전 데이터가 보이지 않아야 함
- 최신 요청 결과만 화면에 반영되어야 함

## 실제 결과
- 로딩 UI와 이전 데이터가 동시에 렌더됨
- 빠른 연속 요청 시 이전 요청 응답이 늦게 도착해 최신 상태를 덮어쓸 수 있음

## 원인 분석
1. `StudyRecordList`에서 `isLoading`이어도 `records.map(...)`를 조건 없이 렌더
2. `useRecordListQuery`, `useMindMapQuery`에 요청 경합(race condition) 방어 로직 부재
3. (별도) `useGoals`의 effect/의존성 구조로 페이지 이동 후 0페이지 재요청 발생

## 수정 내용
- `src/components/records/StudyRecordList.jsx`
  - 로딩 중 리스트/페이지네이션 렌더 차단
- `src/hooks/useRecordApi.js`
  - 요청 시퀀스 가드 추가(최신 요청만 상태 반영)
- `src/hooks/useMindMapApi.js`
  - 요청 시퀀스 가드 추가(최신 요청만 상태 반영)
- `src/hooks/useGoals.js`
  - `loadGoals` 의존성 정리로 페이지 초기화 재요청 제거

## 검증
- `npm run build` 통과
- 수동 확인:
  - Records/MindMap에서 빠른 필터 변경 시 이전 데이터 혼재 현상 미재현
  - Goals에서 다음 페이지 이동 정상 동작

## 참고
- 사용자 혼란도: 중간~높음 (로딩 상태 신뢰 저하)
- 우선순위 제안: High
