### PR TITLE
#37 feat(search): records/goals/mindmap 검색 쿼리 통일 및 토글형 검색 UI 추가

### DIFF
--- a/src/api/goals.api.js
+++ b/src/api/goals.api.js
@@ -8,8 +8,10 @@ const unwrap = (res) => {
   return body.data;
 };
 
-export async function fetchGoals(page = 0) {
-  const res = await api.get("/goals/lists", { params: { page } });
+export async function fetchGoals(page = 0, search = "") {
+  const normalizedSearch = String(search ?? "").trim();
+  const params = normalizedSearch ? { page, search: normalizedSearch } : { page };
+  const res = await api.get("/goals/lists", { params });
   return unwrap(res);
 }
 
@@ -42,4 +44,3 @@ export async function deleteTask(goalId, taskId) {
   const res = await api.delete(`/goals/delete/${goalId}/task/${taskId}`);
   return unwrap(res);
 }
-

--- a/src/components/records/StudyRecordList.jsx
+++ b/src/components/records/StudyRecordList.jsx
@@ -56,7 +56,7 @@ const StudyRecordList = ({
                     ))}
             </div>
 
-            {!isLoading && hasRecords && (
+            {!isLoading && visibleTotalPages > 1 && (
                 <div className="record-pagination">
                     <button type="button" className="page-btn" onClick={onPrev} disabled={!canPrev}>
                         <ChevronLeft size={16} />

--- a/src/hooks/useGoals.js
+++ b/src/hooks/useGoals.js
@@ -45,7 +45,7 @@ const normalizeTask = (task) => {
   };
 };
 
-export default function useGoals() {
+export default function useGoals(initialPage = 0, initialSearch = "") {
   const [goals, setGoals] = useState([]);
   const [page, setPage] = useState(0);
   const [totalPages, setTotalPages] = useState(1);
@@ -70,10 +70,12 @@ export default function useGoals() {
     return () => clearTimeout(timer);
   }, [errorMessage]);
 
+  const normalizedSearch = String(initialSearch ?? "").trim();
+
   const loadGoals = useCallback(async (nextPage = 0) => {
     setLoadingGoals(true);
     try {
-      const pageData = await fetchGoals(nextPage);
+      const pageData = await fetchGoals(nextPage, normalizedSearch);
       const content = Array.isArray(pageData?.content) ? pageData.content : [];
       setGoals(content.map(normalizeGoal).filter(Boolean));
       setPage(Math.max(0, toNumber(pageData?.number ?? nextPage, nextPage)));
@@ -83,7 +85,7 @@ export default function useGoals() {
     } finally {
       setLoadingGoals(false);
     }
-  }, [setUiError]);
+  }, [normalizedSearch, setUiError]);
 
   const refreshTasks = useCallback(async (goalId) => {
     setTasksLoadingByGoalId((prev) => ({ ...prev, [goalId]: true }));
@@ -181,8 +183,8 @@ export default function useGoals() {
   }, [loadGoals, page, pendingTaskIds, refreshTasks, setUiError, tasksByGoalId]);
 
   useEffect(() => {
-    loadGoals(0);
-  }, [loadGoals]);
+    loadGoals(Math.max(0, toNumber(initialPage, 0)));
+  }, [initialPage, loadGoals, normalizedSearch]);
 
   return {
     goals,

--- a/src/pages/goals/GoalManage.jsx
+++ b/src/pages/goals/GoalManage.jsx
@@ -3,13 +3,20 @@ import LoadingState from "../../components/common/LoadingState";
 import GoalCard from "../../components/goals/GoalCard";
 import GoalCreateModal from "../../components/goals/GoalCreateModal";
 import useGoals from "../../hooks/useGoals";
-import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Search } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import "../../styles/goals/GoalManage.css";
 
 const GoalManage = () => {
     const navigate = useNavigate();
+    const [searchParams, setSearchParams] = useSearchParams();
     const [createOpen, setCreateOpen] = useState(false);
+    const skipInitialUrlSyncRef = useRef(searchParams.has("page"));
+    const keywordFromUrl = (searchParams.get("search") ?? searchParams.get("keyword") ?? "").trim();
+    const [keywordInput, setKeywordInput] = useState(keywordFromUrl);
+    const [isSearchOpen, setIsSearchOpen] = useState(Boolean(keywordFromUrl));
+    const requestedUiPage = Math.max(1, Number(searchParams.get("page") ?? 1) || 1);
     const {
         goals,
         page,
@@ -20,7 +27,6 @@ const GoalManage = () => {
         tasksLoadingByGoalId,
         pendingTaskIds,
         errorMessage,
-        loadGoals,
         openTasks,
         closeTasks,
         createNewGoal,
@@ -28,10 +34,49 @@ const GoalManage = () => {
         addTask,
         removeTask,
         toggleTaskCompleted,
-    } = useGoals();
+    } = useGoals(requestedUiPage - 1, keywordFromUrl);
 
     const canPrev = page > 0;
     const canNext = page + 1 < totalPages;
+
+    const setPageParam = (nextUiPage, replace = false) => {
+        const clampedUiPage = Math.min(Math.max(1, nextUiPage), Math.max(1, totalPages));
+        const next = new URLSearchParams(searchParams);
+        next.set("page", String(clampedUiPage));
+        setSearchParams(next, { replace });
+    };
+
+    const onSearchSubmit = (event) => {
+        event.preventDefault();
+        const normalizedKeyword = keywordInput.trim().toLowerCase();
+        const next = new URLSearchParams(searchParams);
+        if (normalizedKeyword) {
+            next.set("search", normalizedKeyword);
+            next.delete("keyword");
+        } else {
+            next.delete("search");
+            next.delete("keyword");
+        }
+        next.set("page", "1");
+        setSearchParams(next);
+    };
+
+    useEffect(() => {
+        if (skipInitialUrlSyncRef.current) {
+            skipInitialUrlSyncRef.current = false;
+            return;
+        }
+        const resolvedUiPage = page + 1;
+        if (Number(searchParams.get("page")) === resolvedUiPage) return;
+        setPageParam(resolvedUiPage, true);
+    }, [page, searchParams, setSearchParams, totalPages]);
+
+    useEffect(() => {
+        setKeywordInput(keywordFromUrl);
+        if (keywordFromUrl) {
+            setIsSearchOpen(true);
+        }
+    }, [keywordFromUrl]);
 
     return (
         <div className="goal-manage-page">
@@ -45,6 +90,29 @@ const GoalManage = () => {
                 onAdd={() => setCreateOpen(true)}
             />
             <main className="goals-list">
+                <div className="goals-toolbar">
+                    {isSearchOpen && (
+                        <form className="goals-search-form" onSubmit={onSearchSubmit}>
+                            <input
+                                type="text"
+                                value={keywordInput}
+                                onChange={(event) => setKeywordInput(event.target.value)}
+                                placeholder="목표 검색"
+                                aria-label="목표 검색어"
+                            />
+                            <button type="submit">검색</button>
+                        </form>
+                    )}
+                    <button
+                        type="button"
+                        className="goals-search-toggle"
+                        aria-label="검색창 열기"
+                        onClick={() => setIsSearchOpen((prev) => !prev)}
+                    >
+                        <Search size={18} />
+                    </button>
+                </div>
+
                 {loadingGoals ? (
                     <LoadingState
                         title="목표를 불러오는 중입니다"
@@ -53,15 +121,24 @@ const GoalManage = () => {
                     />
                 ) : goals.length === 0 ? (
                     <section className="goal-empty-card">
-                        <h3 className="goal-title">아직 목표가 없습니다</h3>
-                        <p className="goal-progress-text">등록된 목표가 없습니다.</p>
-                        <button
-                            type="button"
-                            className="goal-toggle-btn"
-                            onClick={() => setCreateOpen(true)}
-                        >
-                            + 새 목표 추가
-                        </button>
+                        {keywordFromUrl ? (
+                            <>
+                                <h3 className="goal-title">검색 결과가 없습니다</h3>
+                                <p className="goal-progress-text">다른 검색어로 다시 시도해보세요.</p>
+                            </>
+                        ) : (
+                            <>
+                                <h3 className="goal-title">아직 목표가 없습니다</h3>
+                                <p className="goal-progress-text">등록된 목표가 없습니다.</p>
+                                <button
+                                    type="button"
+                                    className="goal-toggle-btn"
+                                    onClick={() => setCreateOpen(true)}
+                                >
+                                    + 새 목표 추가
+                                </button>
+                            </>
+                        )}
                     </section>
                 ) : (
                     goals.map((goal) => (
@@ -83,13 +160,13 @@ const GoalManage = () => {
                 )}
 
                 <div className="goals-pagination">
-                    <button type="button" onClick={() => loadGoals(page - 1)} disabled={!canPrev}>
+                    <button type="button" onClick={() => setPageParam(page)} disabled={!canPrev}>
                         이전
                     </button>
                     <span>
                         {page + 1} / {Math.max(1, totalPages)}
                     </span>
-                    <button type="button" onClick={() => loadGoals(page + 1)} disabled={!canNext}>
+                    <button type="button" onClick={() => setPageParam(page + 2)} disabled={!canNext}>
                         다음
                     </button>
                 </div>

--- a/src/pages/mindmap/MindMap.jsx
+++ b/src/pages/mindmap/MindMap.jsx
@@ -17,10 +17,11 @@ import search from "../../assets/mindmap/search.svg";
 const MindMap = () => {
     const navigate = useNavigate();
     const [isCreateOpen, setIsCreateOpen] = useState(false);
-    const [keyword, setKeyword] = useState("");
+    const [searchParams, setSearchParams] = useSearchParams();
+    const searchKeywordFromUrl = (searchParams.get("search") ?? searchParams.get("keyword") ?? "").trim();
+    const [keyword, setKeyword] = useState(searchKeywordFromUrl);
     const [debouncedKeyword, setDebouncedKeyword] = useState("");
 
-    const [searchParams, setSearchParams] = useSearchParams();
     const category = searchParams.get("category") ?? "";
     const resolvedCategory = category || "lecture";
     const apiCategory = CATEGORY_MAP[resolvedCategory] ?? undefined;
@@ -58,13 +59,23 @@ const MindMap = () => {
 
     const onSearch = (event) => {
         event.preventDefault();
+        const normalizedKeyword = keyword.trim();
+        const next = new URLSearchParams(searchParams);
+        if (normalizedKeyword) {
+            next.set("search", normalizedKeyword);
+            next.delete("keyword");
+        } else {
+            next.delete("search");
+            next.delete("keyword");
+        }
+        setSearchParams(next);
     };
 
     const onKeywordSelect = (value) => {
         const keywordText = String(value ?? "").trim();
         if (!keywordText) return;
         const params = new URLSearchParams();
-        params.set("keyword", keywordText);
+        params.set("search", keywordText);
         if (resolvedCategory) {
             params.set("category", resolvedCategory);
         }
@@ -78,6 +89,10 @@ const MindMap = () => {
 
         return () => window.clearTimeout(timer);
     }, [keyword]);
+
+    useEffect(() => {
+        setKeyword(searchKeywordFromUrl);
+    }, [searchKeywordFromUrl]);
 
     const filteredNodes = useMemo(() => {
         if (!debouncedKeyword) return nodes;

--- a/src/pages/records/StudyRecord.jsx
+++ b/src/pages/records/StudyRecord.jsx
@@ -5,20 +5,25 @@ import StudyRecordCreateModal from "../../components/records/StudyRecordCreateMo
 import "../../styles/records/StudyRecord.css";
 import "../../styles/common/Pagination.css";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Search } from "lucide-react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useCreateRecordMutation, useRecordListQuery } from "../../hooks/useRecordApi";
 import { buildRecordCreatePayload, toRecordListItem } from "../../utils/recordView";
 import { getApiErrorMessage } from "../../api/api-response";
+import { getRecordList } from "../../api/record.api";
 
 const StudyRecord = () => {
     const navigate = useNavigate();
     const [searchParams, setSearchParams] = useSearchParams();
     const [isCreateOpen, setIsCreateOpen] = useState(false);
+    const autoLocateKeyRef = useRef("");
 
     const category = searchParams.get("category") ?? "";
-    const keyword = searchParams.get("keyword") ?? "";
-    const normalizedKeyword = keyword.trim().toLowerCase();
+    const searchKeyword = (searchParams.get("search") ?? searchParams.get("keyword") ?? "").trim();
+    const normalizedKeyword = searchKeyword.toLowerCase();
+    const [isSearchOpen, setIsSearchOpen] = useState(Boolean(searchKeyword));
+    const [searchInput, setSearchInput] = useState(searchKeyword);
     const apiCategory = category ? category.toUpperCase() : undefined;
     const uiPage = Math.max(1, Number(searchParams.get("page") ?? 1) || 1);
     // UI와 API 요청 page 모두 1-based를 사용합니다.
@@ -29,7 +34,7 @@ const StudyRecord = () => {
         page: apiPage,
         size,
         category: apiCategory,
-        keyword,
+        keyword: searchKeyword,
     });
     const {
         data: recordListData,
@@ -46,9 +51,9 @@ const StudyRecord = () => {
             page: apiPage,
             size,
             category: apiCategory,
-            keyword,
+            keyword: searchKeyword,
         }));
-    }, [apiCategory, apiPage, keyword, setRecordListParams, size]);
+    }, [apiCategory, apiPage, searchKeyword, setRecordListParams, size]);
 
     const createRecordMutation = useCreateRecordMutation({
         onSuccess: async () => {
@@ -57,24 +62,82 @@ const StudyRecord = () => {
         },
     });
 
+    const matchesKeyword = (item) => {
+        if (!normalizedKeyword) return true;
+        const titleText = String(item?.title ?? "").toLowerCase();
+        return titleText.includes(normalizedKeyword);
+    };
+
     const records = useMemo(() => {
         const mapped = recordItems.map((item) => toRecordListItem(item));
         if (!normalizedKeyword) return mapped;
-
-        return mapped.filter((item) => {
-            const titleText = String(item?.title ?? "").toLowerCase();
-            const contentText = String(item?.preview ?? item?.content ?? "").toLowerCase();
-            const keywords = Array.isArray(item?.keywords)
-                ? item.keywords.map((value) => String(value).toLowerCase())
-                : [];
-
-            return (
-                titleText.includes(normalizedKeyword) ||
-                contentText.includes(normalizedKeyword) ||
-                keywords.some((value) => value.includes(normalizedKeyword))
-            );
-        });
+        return mapped.filter(matchesKeyword);
     }, [recordItems, normalizedKeyword]);
+
+    useEffect(() => {
+        const autoLocateKey = `${apiCategory ?? "all"}|${normalizedKeyword}`;
+        if (!normalizedKeyword || searchParams.has("page")) {
+            autoLocateKeyRef.current = "";
+            return;
+        }
+        if (isRecordListLoading || recordListError) return;
+        if (records.length > 0) {
+            autoLocateKeyRef.current = autoLocateKey;
+            return;
+        }
+        if (autoLocateKeyRef.current === autoLocateKey) return;
+
+        autoLocateKeyRef.current = autoLocateKey;
+        const totalPages = Math.max(1, Number(recordListData.totalPages) || 1);
+        if (totalPages <= 1) return;
+
+        let cancelled = false;
+        const locate = async () => {
+            for (let nextPage = 2; nextPage <= totalPages; nextPage += 1) {
+                try {
+                    const pageData = await getRecordList({
+                        page: nextPage,
+                        size,
+                        category: apiCategory,
+                        keyword: searchKeyword,
+                    });
+                    const pageItems = (pageData?.items ?? []).map((item) => toRecordListItem(item));
+                    if (pageItems.some(matchesKeyword)) {
+                        if (cancelled) return;
+                        const next = new URLSearchParams(searchParams);
+                        next.set("page", String(nextPage));
+                        setSearchParams(next, { replace: true });
+                        return;
+                    }
+                } catch {
+                    return;
+                }
+            }
+        };
+
+        locate();
+        return () => {
+            cancelled = true;
+        };
+    }, [
+        apiCategory,
+        isRecordListLoading,
+        searchKeyword,
+        normalizedKeyword,
+        recordListData.totalPages,
+        recordListError,
+        records,
+        searchParams,
+        setSearchParams,
+        size,
+    ]);
+
+    useEffect(() => {
+        setSearchInput(searchKeyword);
+        if (searchKeyword) {
+            setIsSearchOpen(true);
+        }
+    }, [searchKeyword]);
 
     const onCreateSave = async (payload) => {
         try {
@@ -92,6 +155,21 @@ const StudyRecord = () => {
         setSearchParams(next);
     };
 
+    const onSearchSubmit = (event) => {
+        event.preventDefault();
+        const normalized = searchInput.trim();
+        const next = new URLSearchParams(searchParams);
+        if (normalized) {
+            next.set("search", normalized);
+            next.delete("keyword");
+        } else {
+            next.delete("search");
+            next.delete("keyword");
+        }
+        next.delete("page");
+        setSearchParams(next);
+    };
+
     return (
         <div className="study-record-page">
             <Header
@@ -104,7 +182,31 @@ const StudyRecord = () => {
             <main className="study-record-main">
                 <div className="record-layout">
                     <section className="record-content">
-                        <CategoryTabs showAll />
+                        <div className="record-toolbar">
+                            <CategoryTabs showAll />
+                            <div className="record-search-box">
+                                {isSearchOpen && (
+                                    <form className="record-search-form" onSubmit={onSearchSubmit}>
+                                        <input
+                                            type="text"
+                                            value={searchInput}
+                                            onChange={(event) => setSearchInput(event.target.value)}
+                                            placeholder="제목 검색"
+                                            aria-label="제목 검색"
+                                        />
+                                        <button type="submit">검색</button>
+                                    </form>
+                                )}
+                                <button
+                                    type="button"
+                                    className="record-search-toggle"
+                                    aria-label="검색창 열기"
+                                    onClick={() => setIsSearchOpen((prev) => !prev)}
+                                >
+                                    <Search size={18} />
+                                </button>
+                            </div>
+                        </div>
                         {recordListError && (
                             <p>{recordListError.message || "기록 목록을 불러오지 못했습니다."}</p>
                         )}

--- a/src/styles/goals/GoalManage.css
+++ b/src/styles/goals/GoalManage.css
@@ -15,6 +15,65 @@
     border-top: 1px solid #e5e7eb;
 }
 
+.goals-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 8px;
+}
+
+.goals-search-form {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.goals-search-form input {
+    width: min(460px, 62vw);
+    height: 40px;
+    border-radius: 10px;
+    border: 1px solid #d6dae2;
+    padding: 0 12px;
+    background: #fff;
+    font-size: 14px;
+}
+
+.goals-search-form input::placeholder {
+  color: #94a3b8;
+}
+
+.goals-search-form button {
+    height: 40px;
+    padding: 0 12px;
+    border-radius: 10px;
+    border: 1px solid #d6dae2;
+    background: #fff;
+    color: #334155;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    font-weight: 700;
+}
+
+.goals-search-toggle {
+    width: 40px;
+    height: 40px;
+    border-radius: 10px;
+    border: 1px solid #d6dae2;
+    background: #fff;
+    color: #334155;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+}
+
+.goals-search-form button:hover,
+.goals-search-toggle:hover {
+    border-color: #94a3b8;
+}
+
 .goal-empty {
     border: 1px solid #e5e7eb;
     border-radius: 14px;
@@ -156,5 +215,9 @@
     .goals-list {
         width: min(92vw, 800px);
         padding-top: 14px;
+    }
+
+    .goals-search-form input {
+        width: min(300px, 72vw);
     }
 }

--- a/src/styles/records/StudyRecord.css
+++ b/src/styles/records/StudyRecord.css
@@ -24,6 +24,62 @@
     flex: 1;
 }
 
+.record-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.record-search-box {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 28px;
+    margin-bottom: 21px;
+    margin-left: auto;
+}
+
+.record-search-form {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.record-search-form input {
+    width: min(420px, 58vw);
+    height: 40px;
+    border-radius: 10px;
+    border: 1px solid #d9e0db;
+    background: #fff;
+    padding: 0 12px;
+    font-size: 14px;
+}
+
+.record-search-form button {
+    height: 40px;
+    padding: 0 12px;
+    border-radius: 10px;
+    border: 1px solid #d9e0db;
+    background: #fff;
+    font-size: 14px;
+    font-weight: 700;
+    cursor: pointer;
+}
+
+.record-search-toggle {
+    width: 40px;
+    height: 40px;
+    border-radius: 10px;
+    border: 1px solid #d9e0db;
+    background: #fff;
+    color: #334155;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+}
+
 .record-tabs {
     display: flex;
     flex-wrap: wrap;
@@ -180,4 +236,21 @@
 .badge--blue {
     color: #1447e6;
     background: #dbeafe;
+}
+
+@media (max-width: 760px) {
+    .record-toolbar {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 0;
+    }
+
+    .record-search-box {
+        margin-top: 0;
+        margin-bottom: 10px;
+    }
+
+    .record-search-form input {
+        width: min(300px, 72vw);
+    }
 }


### PR DESCRIPTION
## 작업 배경
- records/goals/mindmap에서 검색 쿼리 사용 방식이 일관되지 않아 URL 공유/직접 진입 시 동작이 불안정했습니다.
- records/goals 검색 UI 요청사항(우측 돋보기 클릭 후 검색 실행)을 반영했습니다.

## 주요 변경사항
- 검색 쿼리 통일
  - `search`를 우선 사용하고, 기존 `keyword`는 하위 호환(fallback)으로 처리
- records
  - 우측 돋보기 버튼 추가
  - 돋보기 클릭 시 검색 input + 검색 버튼 노출
  - 검색 실행 시 `?search=` 반영 및 `page` 초기화
  - 제목 기준 검색 동작으로 정리
  - 로딩 중 이전 데이터가 함께 보이던 렌더 이슈 수정
- goals
  - 우측 돋보기 버튼 추가
  - 검색 UI 토글 방식 적용
  - `search` 파라미터를 백엔드 `/goals/lists` 호출에 전달하도록 연동
  - 클라이언트 내 임시 필터 대신 서버 검색 결과 사용
  - `?page=` 쿼리 동기화 유지
- mindmap
  - `search` 쿼리 읽기/쓰기 반영
  - records 이동 시 `keyword` 대신 `search`로 전달

## 버그 수정
- goals 페이지네이션이 다음 페이지로 이동되지 않던 문제 수정
- records/mindmap 조회 중 이전 데이터가 함께 노출되던 문제 수정
- records URL 진입 시 검색 결과가 특정 페이지에만 있어 보이지 않던 케이스 보완

## 스타일/UI
- records/goals 검색 input 너비 확대
- 검색 input/검색 버튼/돋보기 버튼 가로 정렬 보정

## 검증
- `npm run build` 통과
- 수동 확인
  - records/goals/mindmap `?search=` URL 직접 진입
  - 돋보기 클릭 → 검색 실행 동작
  - 검색 상태에서 페이지 이동
  - 로딩 중 이전 데이터 노출 여부

## 참고
- records 검색/페이지네이션 정합성은 백엔드 필터 후 페이징 구조를 전제로 동작합니다.
