### PR TITLE
#42 feat: 더 알아보기 페이지 구현 및 접속 시 로딩창 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,59 @@
-import { BrowserRouter } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { BrowserRouter, Navigate, useLocation } from "react-router-dom";
 import AppRoutes from "./routes/AppRoutes";
+import LoadingScreen from "./components/LoadingScreen";
+import useAppBootstrap from "./hooks/useAppBootstrap";
+import "./styles/LoadingScreen.css";
+
+function AppGate() {
+    const location = useLocation();
+    const { ready, bootError } = useAppBootstrap({
+        minDelayMs: 500,
+        timeoutMs: 7000,
+        enableHealthCheck: false,
+    });
+    const [showLoading, setShowLoading] = useState(true);
+    const [isFading, setIsFading] = useState(false);
+
+    useEffect(() => {
+        if (!ready) {
+            setShowLoading(true);
+            setIsFading(false);
+            return;
+        }
+
+        setIsFading(true);
+        const timerId = window.setTimeout(() => {
+            setShowLoading(false);
+        }, 200);
+
+        return () => {
+            window.clearTimeout(timerId);
+        };
+    }, [ready]);
+
+    if (showLoading) {
+        return <LoadingScreen message="로딩중..." fading={isFading} />;
+    }
+
+    if (bootError?.type === "NETWORK") {
+        if (location.pathname === "/network-error") {
+            return <AppRoutes />;
+        }
+        return <Navigate to="/network-error" replace />;
+    }
+
+    if (location.pathname === "/network-error") {
+        return <Navigate to="/" replace />;
+    }
+
+    return <AppRoutes />;
+}
 
 export default function App() {
     return (
         <BrowserRouter>
-            <AppRoutes />
+            <AppGate />
         </BrowserRouter>
     );
 }

--- a/src/auth/AuthBootstrapper.jsx
+++ b/src/auth/AuthBootstrapper.jsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from "react";
 import { useAuth } from "../context/AuthContext";
 
 export default function AuthBootstrapper({ children }) {
-    const { authReady, setAuthReady, refreshAuth } = useAuth();
+    const { setAuthReady, refreshAuth } = useAuth();
     const lastRefreshAtRef = useRef(0);
 
     useEffect(() => {
@@ -46,6 +46,5 @@ export default function AuthBootstrapper({ children }) {
         };
     }, [refreshAuth]);
 
-    if (!authReady) return null;
     return children;
 }

--- a/src/components/LoadingScreen.jsx
+++ b/src/components/LoadingScreen.jsx
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+import "../styles/LoadingScreen.css";
+
+export default function LoadingScreen({ message = "로딩중...", fading = false }) {
+    useEffect(() => {
+        const previousBodyOverflow = document.body.style.overflow;
+        document.body.style.overflow = "hidden";
+
+        return () => {
+            document.body.style.overflow = previousBodyOverflow;
+        };
+    }, []);
+
+    return (
+        <div className={`loading-screen${fading ? " is-fading" : ""}`}>
+            <div className="loading-screen-status" role="status" aria-live="polite" aria-busy="true">
+                <div className="loading-screen-brand">Knowledge Garden</div>
+                <div className="loading-screen-spinner" aria-hidden="true" />
+                <p className="loading-screen-message">{message}</p>
+                <p className="loading-screen-subtext">지식을 연결하는 중입니다</p>
+            </div>
+        </div>
+    );
+}

--- a/src/components/home/InfoDrawer.jsx
+++ b/src/components/home/InfoDrawer.jsx
@@ -1,0 +1,190 @@
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+import { ChevronDown, Filter, Lightbulb, Link2, X } from "lucide-react";
+
+const POINTS = [
+    {
+        icon: Link2,
+        text: "자동 연결 규칙: 함께 등장할수록 더 굵게",
+    },
+    {
+        icon: Filter,
+        text: "필터로 보기: 기간/카테고리/상위 키워드",
+    },
+    {
+        icon: Lightbulb,
+        text: "인사이트: 중심 주제·허브 키워드·최근 성장",
+    },
+];
+
+const FAQS = [
+    {
+        question: "키워드는 직접 입력도 가능한가요?",
+        answer: "가능해요. 추천도 지원해요.",
+    },
+    {
+        question: "내 기록은 공개되나요?",
+        answer: "아쉽지만 개인정보 보호를 위해 비공개로 제공돼요.",
+    },
+    {
+        question: "삭제하면 복구되나요?",
+        answer: "삭제 후 복구 불가(안내 문구 포함).",
+    },
+];
+
+export default function InfoDrawer({ open, onClose }) {
+    const titleId = useId();
+    const descId = useId();
+    const panelRef = useRef(null);
+    const closeButtonRef = useRef(null);
+    const [openFaqIndex, setOpenFaqIndex] = useState(0);
+
+    const focusableSelector = useMemo(
+        () =>
+            'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        []
+    );
+
+    useEffect(() => {
+        if (!open) return undefined;
+
+        const previousBodyOverflow = document.body.style.overflow;
+        document.body.style.overflow = "hidden";
+        closeButtonRef.current?.focus();
+
+        const handleKeyDown = (event) => {
+            if (event.key === "Escape") {
+                event.preventDefault();
+                onClose?.();
+                return;
+            }
+
+            if (event.key !== "Tab") return;
+
+            const panel = panelRef.current;
+            if (!panel) return;
+
+            const focusableElements = Array.from(panel.querySelectorAll(focusableSelector));
+            if (focusableElements.length === 0) return;
+
+            const first = focusableElements[0];
+            const last = focusableElements[focusableElements.length - 1];
+
+            if (event.shiftKey && document.activeElement === first) {
+                event.preventDefault();
+                last.focus();
+                return;
+            }
+
+            if (!event.shiftKey && document.activeElement === last) {
+                event.preventDefault();
+                first.focus();
+            }
+        };
+
+        document.addEventListener("keydown", handleKeyDown);
+
+        return () => {
+            document.removeEventListener("keydown", handleKeyDown);
+            document.body.style.overflow = previousBodyOverflow;
+        };
+    }, [focusableSelector, onClose, open]);
+
+    if (!open) return null;
+
+    return (
+        <div
+            className="info-drawer-overlay"
+            role="presentation"
+            onMouseDown={(event) => {
+                if (event.target === event.currentTarget) onClose?.();
+            }}
+        >
+            <aside
+                ref={panelRef}
+                className="info-drawer"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby={titleId}
+                aria-describedby={descId}
+            >
+                <button
+                    ref={closeButtonRef}
+                    type="button"
+                    className="info-drawer-close"
+                    aria-label="닫기"
+                    onClick={() => onClose?.()}
+                >
+                    <X size={18} />
+                </button>
+
+                <header className="info-drawer-header">
+                    <h2 id={titleId} className="info-drawer-title">
+                        기록이 연결되면, 복습과 성장이 쉬워져요
+                    </h2>
+                    <p id={descId} className="info-drawer-subtitle">
+                        당신의 강의·독서·프로젝트 기록을 키워드로 묶고, 함께 등장한 주제는 더 강하게
+                        연결해요.
+                    </p>
+                </header>
+
+                <section className="info-drawer-section" aria-label="주요 포인트">
+                    <ul className="info-point-list">
+                        {POINTS.map((point) => {
+                            const Icon = point.icon;
+                            return (
+                                <li key={point.text} className="info-point-item">
+                                    <span className="info-point-icon" aria-hidden="true">
+                                        <Icon size={18} />
+                                    </span>
+                                    <span>{point.text}</span>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                </section>
+
+                <section className="info-drawer-section" aria-label="자주 묻는 질문">
+                    <h3 className="info-faq-heading">FAQ</h3>
+                    <div className="info-faq-list">
+                        {FAQS.map((faq, index) => {
+                            const expanded = openFaqIndex === index;
+                            const buttonId = `${titleId}-faq-btn-${index}`;
+                            const panelId = `${titleId}-faq-panel-${index}`;
+                            return (
+                                <div key={faq.question} className="info-faq-item">
+                                    <button
+                                        id={buttonId}
+                                        type="button"
+                                        className="info-faq-button"
+                                        aria-expanded={expanded}
+                                        aria-controls={panelId}
+                                        onClick={() =>
+                                            setOpenFaqIndex((prev) => (prev === index ? -1 : index))
+                                        }
+                                    >
+                                        <span>Q{index + 1}. {faq.question}</span>
+                                        <ChevronDown
+                                            className={`info-faq-chevron${expanded ? " is-open" : ""}`}
+                                            size={18}
+                                            aria-hidden="true"
+                                        />
+                                    </button>
+                                    {expanded && (
+                                        <div
+                                            id={panelId}
+                                            role="region"
+                                            aria-labelledby={buttonId}
+                                            className="info-faq-answer"
+                                        >
+                                            A{index + 1}. {faq.answer}
+                                        </div>
+                                    )}
+                                </div>
+                            );
+                        })}
+                    </div>
+                </section>
+            </aside>
+        </div>
+    );
+}

--- a/src/hooks/useAppBootstrap.js
+++ b/src/hooks/useAppBootstrap.js
@@ -1,0 +1,169 @@
+import { useCallback, useEffect, useState } from "react";
+import { getAccessToken, getStoredUser } from "../lib/token";
+import { refreshAccessToken } from "../lib/auth/refresh";
+
+const BOOT_ERROR_TYPES = {
+    NETWORK: "NETWORK",
+    AUTH: "AUTH",
+    SERVER: "SERVER",
+    UNKNOWN: "UNKNOWN",
+};
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const NETWORK_MESSAGE = "네트워크가 불안정합니다.";
+const AUTH_MESSAGE = "인증 상태를 확인할 수 없습니다.";
+const SERVER_MESSAGE = "서버 상태가 불안정합니다.";
+const UNKNOWN_MESSAGE = "초기화 중 오류가 발생했습니다.";
+
+const getErrorMessage = (error) => {
+    if (typeof error?.message === "string" && error.message.trim()) {
+        return error.message;
+    }
+    return UNKNOWN_MESSAGE;
+};
+
+const createBootError = (type, message) => ({ type, message });
+
+const classifyError = (error) => {
+    const status = error?.status ?? error?.response?.status;
+
+    if (status === 401 || status === 403) {
+        return createBootError(BOOT_ERROR_TYPES.AUTH, AUTH_MESSAGE);
+    }
+
+    if (typeof status === "number" && status >= 500) {
+        return createBootError(BOOT_ERROR_TYPES.SERVER, SERVER_MESSAGE);
+    }
+
+    const name = String(error?.name ?? "");
+    const code = String(error?.code ?? "");
+    const message = String(error?.message ?? "").toLowerCase();
+
+    if (
+        name === "AbortError" ||
+        code === "ECONNABORTED" ||
+        message.includes("timeout") ||
+        message.includes("failed to fetch") ||
+        message.includes("network error") ||
+        message.includes("networkerror")
+    ) {
+        return createBootError(BOOT_ERROR_TYPES.NETWORK, NETWORK_MESSAGE);
+    }
+
+    return createBootError(BOOT_ERROR_TYPES.UNKNOWN, getErrorMessage(error));
+};
+
+const toErrorWithStatus = (status, message) => {
+    const error = new Error(message);
+    error.status = status;
+    return error;
+};
+
+const fetchWithTimeout = async (url, timeoutMs) => {
+    const controller = new AbortController();
+    const timerId = window.setTimeout(() => {
+        controller.abort();
+    }, timeoutMs);
+
+    try {
+        const response = await fetch(url, {
+            method: "GET",
+            cache: "no-store",
+            credentials: "include",
+            signal: controller.signal,
+        });
+        return response;
+    } finally {
+        window.clearTimeout(timerId);
+    }
+};
+
+const resolveHealthUrl = () => {
+    const base = String(import.meta.env.VITE_BACKEND_BASE_URL ?? "").replace(/\/+$/, "");
+    if (!base) return "/api/health";
+    return `${base}/api/health`;
+};
+
+const checkNetworkHealth = async (timeoutMs) => {
+    if (navigator.onLine === false) {
+        throw createBootError(BOOT_ERROR_TYPES.NETWORK, NETWORK_MESSAGE);
+    }
+
+    const response = await fetchWithTimeout(resolveHealthUrl(), timeoutMs);
+    if (!response.ok) {
+        throw toErrorWithStatus(response.status, `health check failed: ${response.status}`);
+    }
+};
+
+const loadRuntimeTheme = () => {
+    const savedTheme = window.localStorage.getItem("theme");
+    if (!savedTheme) return;
+    document.documentElement.dataset.theme = savedTheme;
+};
+
+export default function useAppBootstrap({
+    minDelayMs = 500,
+    timeoutMs = 7000,
+    enableHealthCheck = false,
+} = {}) {
+    const [ready, setReady] = useState(false);
+    const [bootError, setBootError] = useState(null);
+    const [attempt, setAttempt] = useState(0);
+
+    const retry = useCallback(() => {
+        setReady(false);
+        setBootError(null);
+        setAttempt((prev) => prev + 1);
+    }, []);
+
+    useEffect(() => {
+        let cancelled = false;
+
+        const runBootstrap = async () => {
+            setReady(false);
+            setBootError(null);
+            const delayPromise = sleep(minDelayMs);
+
+            try {
+                if (navigator.onLine === false) {
+                    throw createBootError(BOOT_ERROR_TYPES.NETWORK, NETWORK_MESSAGE);
+                }
+
+                if (enableHealthCheck) {
+                    await checkNetworkHealth(timeoutMs);
+                }
+
+                const token = getAccessToken();
+                const user = getStoredUser();
+
+                if (token && !user) {
+                    await refreshAccessToken();
+                }
+
+                loadRuntimeTheme();
+            } catch (error) {
+                if (!cancelled) {
+                    const nextError =
+                        error?.type && error?.message
+                            ? error
+                            : classifyError(error);
+                    setBootError(nextError);
+                }
+            } finally {
+                await delayPromise;
+                if (!cancelled) {
+                    setReady(true);
+                }
+            }
+        };
+
+        runBootstrap();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [attempt, enableHealthCheck, minDelayMs, timeoutMs]);
+
+    return { ready, bootError, retry };
+}

--- a/src/pages/home/Home.jsx
+++ b/src/pages/home/Home.jsx
@@ -1,5 +1,7 @@
+import { useRef, useState } from "react";
 import Header from "../../components/common/Header";
 import FeatureCard from "../../components/FeatureCard";
+import InfoDrawer from "../../components/home/InfoDrawer";
 import "../../styles/global.css";
 import "../../styles/home.css";
 
@@ -48,6 +50,8 @@ const FEATURES = [
 
 export default function Home() {
     const navigate = useNavigate();
+    const [infoOpen, setInfoOpen] = useState(false);
+    const moreInfoButtonRef = useRef(null);
 
     const onStartGarden = () => {
         const token = getAccessToken();
@@ -57,6 +61,14 @@ export default function Home() {
             return;
         }
         navigate("/dashboard");
+    };
+
+    const openInfoDrawer = () => setInfoOpen(true);
+    const closeInfoDrawer = () => {
+        setInfoOpen(false);
+        requestAnimationFrame(() => {
+            moreInfoButtonRef.current?.focus();
+        });
     };
 
     return (
@@ -73,7 +85,16 @@ export default function Home() {
 
                     <div className="hero-actions">
                         <button className="primary-btn large" onClick={onStartGarden}>내 지식 정원 가꾸기</button>
-                        <button className="ghost-btn large">더 알아보기</button>
+                        <button
+                            ref={moreInfoButtonRef}
+                            className="ghost-btn large"
+                            type="button"
+                            aria-haspopup="dialog"
+                            aria-expanded={infoOpen}
+                            onClick={openInfoDrawer}
+                        >
+                            더 알아보기
+                        </button>
                     </div>
                 </div>
             </section>
@@ -105,6 +126,7 @@ export default function Home() {
                     무료로 시작하기
                 </button>
             </section> */}
+            <InfoDrawer open={infoOpen} onClose={closeInfoDrawer} />
         </div>
     );
 }

--- a/src/styles/LoadingScreen.css
+++ b/src/styles/LoadingScreen.css
@@ -1,0 +1,105 @@
+.loading-screen {
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: radial-gradient(circle at top, #f4f9ff 0%, #ffffff 62%);
+    opacity: 1;
+    transition: opacity 200ms ease;
+}
+
+.loading-screen.is-fading {
+    opacity: 0;
+    pointer-events: none;
+}
+
+.loading-screen-status {
+    min-width: 220px;
+    padding: 24px 22px;
+    border: 1px solid #e2e8f0;
+    border-radius: 16px;
+    background: #ffffff;
+    box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
+    text-align: center;
+}
+
+.loading-screen-brand {
+    margin: 0 0 14px;
+    font-size: 20px;
+    font-weight: 900;
+    letter-spacing: -0.02em;
+    color: #0f172a;
+}
+
+.loading-screen-spinner {
+    width: 34px;
+    height: 34px;
+    margin: 0 auto;
+    border-radius: 999px;
+    border: 3px solid #dbeafe;
+    border-top-color: #2563eb;
+    animation: loading-spin 900ms linear infinite;
+}
+
+.loading-screen-message {
+    margin: 14px 0 0;
+    color: #111827;
+    font-weight: 700;
+}
+
+.loading-screen-subtext {
+    margin: 6px 0 0;
+    color: #64748b;
+    font-size: 14px;
+}
+
+.app-bootstrap-error {
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #f8fafc;
+    padding: 16px;
+}
+
+.app-bootstrap-error-card {
+    width: min(92vw, 420px);
+    background: #ffffff;
+    border: 1px solid #e2e8f0;
+    border-radius: 14px;
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.08);
+    padding: 22px;
+}
+
+.app-bootstrap-error-title {
+    margin: 0;
+    font-size: 20px;
+    color: #0f172a;
+}
+
+.app-bootstrap-error-text {
+    margin: 10px 0 0;
+    color: #475569;
+    line-height: 1.6;
+}
+
+.app-bootstrap-error-button {
+    margin-top: 16px;
+    width: 100%;
+    border: 0;
+    border-radius: 10px;
+    padding: 11px 14px;
+    background: #2563eb;
+    color: #ffffff;
+    font-size: 15px;
+    font-weight: 800;
+    cursor: pointer;
+}
+
+@keyframes loading-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -296,3 +296,190 @@
     transform: translateY(-2px);
     box-shadow: 0 8px 20px rgba(0, 0, 0, 0.25);
 }
+
+.info-drawer-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.45);
+    z-index: 1200;
+    display: flex;
+    justify-content: flex-end;
+    animation: fade-in 180ms ease-out;
+}
+
+.info-drawer {
+    width: min(92vw, 500px);
+    height: 100%;
+    background: #ffffff;
+    border-left: 1px solid #e2e8f0;
+    box-shadow: -14px 0 36px rgba(15, 23, 42, 0.2);
+    padding: 24px 20px 28px;
+    overflow-y: auto;
+    animation: slide-in-right 220ms ease-out;
+}
+
+.info-drawer-close {
+    margin-left: auto;
+    width: 34px;
+    height: 34px;
+    border-radius: 999px;
+    border: 1px solid #e2e8f0;
+    background: #fff;
+    color: #111827;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+}
+
+.info-drawer-header {
+    margin-top: 14px;
+}
+
+.info-drawer-title {
+    margin: 0;
+    font-size: 28px;
+    line-height: 1.35;
+    letter-spacing: -0.02em;
+    color: #0f172a;
+}
+
+.info-drawer-subtitle {
+    margin: 14px 0 0;
+    color: #475569;
+    line-height: 1.7;
+}
+
+.info-drawer-section {
+    margin-top: 24px;
+}
+
+.info-point-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 10px;
+}
+
+.info-point-item {
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    padding: 12px;
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    color: #0f172a;
+    line-height: 1.5;
+}
+
+.info-point-icon {
+    width: 30px;
+    height: 30px;
+    border-radius: 8px;
+    background: #eff6ff;
+    color: #2563eb;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.info-faq-heading {
+    margin: 0 0 10px;
+    font-size: 18px;
+    color: #0f172a;
+}
+
+.info-faq-list {
+    display: grid;
+    gap: 8px;
+}
+
+.info-faq-item {
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    overflow: hidden;
+    background: #fff;
+}
+
+.info-faq-button {
+    width: 100%;
+    border: 0;
+    padding: 12px 14px;
+    background: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    text-align: left;
+    font-weight: 700;
+    color: #0f172a;
+    cursor: pointer;
+}
+
+.info-faq-chevron {
+    transition: transform 180ms ease;
+    flex-shrink: 0;
+}
+
+.info-faq-chevron.is-open {
+    transform: rotate(180deg);
+}
+
+.info-faq-answer {
+    border-top: 1px solid #e2e8f0;
+    padding: 12px 14px 14px;
+    color: #334155;
+    line-height: 1.6;
+    background: #f8fafc;
+}
+
+@keyframes fade-in {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+
+@keyframes slide-in-right {
+    from {
+        transform: translateX(100%);
+    }
+    to {
+        transform: translateX(0);
+    }
+}
+
+@keyframes slide-in-bottom {
+    from {
+        transform: translateY(100%);
+    }
+    to {
+        transform: translateY(0);
+    }
+}
+
+@media (max-width: 700px) {
+    .info-drawer-overlay {
+        justify-content: stretch;
+        align-items: flex-end;
+    }
+
+    .info-drawer {
+        width: 100%;
+        max-height: min(82vh, 700px);
+        height: auto;
+        border-left: 0;
+        border-top: 1px solid #e2e8f0;
+        border-radius: 16px 16px 0 0;
+        box-shadow: 0 -10px 30px rgba(15, 23, 42, 0.2);
+        animation: slide-in-bottom 220ms ease-out;
+    }
+
+    .info-drawer-title {
+        font-size: 22px;
+    }
+}


### PR DESCRIPTION
## Description
앱 초기 진입 부트스트랩 흐름을 정리하고, 로딩/네트워크 예외 동작을 개선했습니다.  
추가로 랜딩 히어로의 `더 알아보기` 드로어 UI를 구현했습니다.

## Implemented
- App Gate 기반 초기 부트스트랩 훅(`useAppBootstrap`) 적용
- 최초 진입 시 `LoadingScreen` 표시 + 최소 표시 시간(500ms) + 페이드아웃 전환
- 네트워크 불안정 시 `/network-error`로 `replace` 라우팅
- `/network-error`에서 새로고침 시 부트스트랩 재실행 후 정상 시 자동 진입
- 랜딩 히어로 `더 알아보기` 드로어(`InfoDrawer`) 구현
- 드로어 접근성/상호작용 처리: `role="dialog"`, `aria-*`, ESC 닫기, 오버레이 닫기, 포커스 복귀, 스크롤 락
- FAQ 아코디언 토글 UI 구현

## Check
- [x] 기능 구현
- [x] 예외 처리
- [x] 테스트

## Test
- `npm run build` 실행 및 성공 확인
- 로딩 화면 노출 → 자동 전환(페이드아웃) 동작 확인
- 오프라인(네트워크 차단) 시 `/network-error` 이동, 새로고침 후 복구 동작 확인
- `더 알아보기` 버튼 클릭 시 드로어 오픈/닫기(X, 오버레이, ESC) 및 FAQ 아코디언 동작 확인

## Notice
- 현재 부트스트랩의 health check는 기본 비활성(`enableHealthCheck: false`) 상태입니다.
- 환경변수 파일(`.env*`)은 gitignore 대상이므로 로컬에 별도 생성이 필요합니다.
